### PR TITLE
Fixes in kabamland2.load_or_build_detector() and add lensmaterials.create_scintillation_material()

### DIFF
--- a/lensmaterials.py
+++ b/lensmaterials.py
@@ -79,3 +79,54 @@ def get_scintillation_material():
 
 	return _ls
 
+##### Scintillation parameters #####  Currenty unused
+Scnt_PP = np.array([ 6.6*eV, 6.7*eV, 6.8*eV, 6.9*eV, 7.0*eV, 7.1*eV, 7.2*eV, 7.3*eV, 7.4*eV ])
+
+Scnt_FAST = np.array([ 0.000134, 0.004432, 0.053991, 0.241971, 0.398942, 0.000134, 0.004432, 0.053991, 0.241971 ])
+Scnt_SLOW = np.array([ 0.000010, 0.000020, 0.000030, 0.004000, 0.008000, 0.005000, 0.020000, 0.001000, 0.000010 ])
+
+# Set RI to 1.0 to turn off Cherenkov light
+ls_refractive_index = 1.5
+
+def k_thresh(r_idx,m=0.511):
+        # return the Cerenkov threshold energy (kinetic) for a given particle (mass in MeV) crossing media with r_idx as refractive index
+        s = r_idx*r_idx
+        return m*(1/np.sqrt(1.0-1.0/s)-1.0)
+
+_ls = None
+
+# TODO: Many modules rely on lm.ls which will have to be changed
+# "create" is not really a great name for this.  Use "get" or perhaps no prefix?
+def create_scintillation_material():
+        global _ls
+        if _ls is None:
+                # ls stands for "liquid scintillator"
+                _ls = Material('liquid-scintillator')
+                _ls.set('refractive_index', ls_refractive_index)
+                _ls.set('absorption_length', 1e8)
+                _ls.set('scattering_length', 1e8)
+                _ls.density = 0.780
+                _ls.composition = {'H': 0.663210, 'C': 0.336655, 'N': 1.00996e-4, 'O': 3.36655e-5}
+
+                _ls.set('refractive_index', np.linspace(ls_refractive_index, ls_refractive_index, 38))
+
+                # Scintillation properties
+                energy_scint = list((2 * pi * hbarc / (np.linspace(320, 300, 11).astype(float) * nanometer)))
+                spect_scint = list([0.04, 0.07, 0.20, 0.49, 0.84, 1.00, 0.83, 0.55, 0.40, 0.17, 0.03])
+                # See https://geant4.web.cern.ch/geant4/UserDocumentation/UsersGuides/ForApplicationDeveloper/html/ch02s03.html
+                # Need to validate that the types are being passed through properly.  Previously was using list(Scnt_PP.astype(float)
+                _ls.set_scintillation_property('FASTCOMPONENT', energy_scint, spect_scint)
+                # scint.set_scintillation_property('SLOWCOMPONENT', Scnt_PP, Scnt_SLOW);
+
+                # This causes different effects from using the separate FAST and SLOW components below
+                #  From KamLAND photocathode paper   # Per Scott
+                # kabamland.detector_material.set_scintillation_property('SCINTILLATION', [float(2*pi*hbarc / (360. * nanometer))], [float(1.0)])
+
+                # TODO: These keys much match the Geant4 pmaterial property names.  (Magic strings)
+                _ls.set_scintillation_property('SCINTILLATIONYIELD', 8000. / MeV)  # Was 10000 originally
+                _ls.set_scintillation_property('RESOLUTIONSCALE', 1.0)  # Was 1.0 originally
+                _ls.set_scintillation_property('FASTTIMECONSTANT', 1. * ns)
+                _ls.set_scintillation_property('SLOWTIMECONSTANT', 10. * ns)
+                _ls.set_scintillation_property('YIELDRATIO', 1.0)  # Was 0.8 - I think this is all fast
+
+        return _ls


### PR DESCRIPTION
Fix the ability to load material and scintillation parameters from the pickle configuration file, as well as override what is in the pickle file.
